### PR TITLE
Add module shutdown cleanup for database service

### DIFF
--- a/packages/database/src/database.service.ts
+++ b/packages/database/src/database.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Inject, OnModuleInit } from "@nestjs/common";
+import { Injectable, Inject, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema";
 import { DB_OPTIONS, DBConfigType } from "./database.interface";
 
 @Injectable()
-export class DatabaseService implements OnModuleInit {
+export class DatabaseService implements OnModuleInit, OnModuleDestroy {
   private pool: Pool;
   public db: ReturnType<typeof drizzle>;
 


### PR DESCRIPTION
## Summary
- implement `OnModuleDestroy` to ensure the database connection pool closes when the module shuts down

## Testing
- `pnpm --filter @task-mgmt/database test --passWithNoTests`
- `pnpm --filter @task-mgmt/database build`


------
https://chatgpt.com/codex/tasks/task_e_689c80f98d5c832b823f669749f896ca