### PR TITLE
chore: add weekly pnpm version bump workflow

### DIFF
--- a/.github/workflows/weekly-version-bump.yml
+++ b/.github/workflows/weekly-version-bump.yml
@@ -1,0 +1,46 @@
+name: Weekly Version Bump
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+        env:
+          CI: true
+
+      - name: Bump versions
+        run: pnpm version patch -r --no-git-tag-version
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: weekly version bump"
+          branch: chore/weekly-version-bump
+          title: "chore: weekly version bump"
+          body: "## Summary\n- Weekly version bump"
+          base: main


### PR DESCRIPTION
## Summary
- schedule weekly workflow to bump package versions via pnpm
- open a pull request instead of pushing directly to main

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8268f7a0832baee480342d2ebf1b