### PR TITLE
Release database connection on module initialization

### DIFF
--- a/packages/database/src/database.service.ts
+++ b/packages/database/src/database.service.ts
@@ -5,7 +5,7 @@ import {
   OnModuleDestroy,
 } from "@nestjs/common";
 import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
 import * as schema from "./schema";
 import { DB_OPTIONS, DBConfigType } from "./database.interface";
 
@@ -28,12 +28,15 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleInit() {
+    let client: PoolClient | undefined;
     try {
-      await this.pool.connect();
+      client = await this.pool.connect();
       console.log("Connected to database with Drizzle");
     } catch (error) {
       console.error("Failed to connect to database:", error);
       throw error;
+    } finally {
+      client?.release();
     }
   }
 


### PR DESCRIPTION
## Summary
- capture database connection during module init and release it back to the pool

## Testing
- `pnpm --filter @task-mgmt/database lint`
- `pnpm --filter @task-mgmt/database exec jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689c88715aa0832b8a207f26ed146efe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved database connection management during initialization to always release connections, preventing rare connection leaks and reducing risk of startup failures.
  * Enhances overall stability and performance under error conditions and sustained load, leading to more reliable launches, fewer intermittent errors, and smoother long‑term operation.
  * No changes to user workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->