### PR TITLE
chore(package): update package.json for shared-types and shared-utils

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -2,11 +2,7 @@
   "name": "@task-mgmt/shared-types",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
     "lint": "eslint src --ext .ts",
     "test": "jest"
   },
@@ -20,5 +16,8 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.1"
+  },
+  "exports": {
+    ".": "./src/index.ts"
   }
 }

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -2,11 +2,7 @@
   "name": "@task-mgmt/shared-utils",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
     "lint": "eslint src --ext .ts",
     "test": "jest"
   },
@@ -23,5 +19,8 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.1"
+  },
+  "exports": {
+    ".": "./src/index.ts"
   }
 }


### PR DESCRIPTION
- Removed 'main' and 'types' fields from package.json.
- Added 'exports' field to specify entry point for both shared-types and shared-utils packages.
- Cleaned up build and dev scripts to streamline package management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized module exports across shared packages using explicit package exports.
  * Removed legacy main/types fields and build/dev scripts from package manifests.
* **Impact**
  * Cleaner, more reliable imports from the package root with a clearly defined public API.
  * Improved compatibility with modern tooling and bundlers.
  * No runtime behavior changes; existing consumers should continue working with simplified import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->